### PR TITLE
[MRG] Add YOLO format export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Both interfaces produce identical output:
 |--------|----------|-------------|
 | CSV | `annotations/annotations.csv` | `image_path,x1,y1,x2,y2,label` per row |
 | Pascal VOC XML | `annotations/annotations_voc/` | One XML file per image |
+| YOLO | `annotations/annotations_yolo/` | One `.txt` file per image and `classes.txt` |
 
 ---
 

--- a/web/README.md
+++ b/web/README.md
@@ -13,7 +13,7 @@ A browser-based image annotation tool built with React, TypeScript, and FastAPI.
 - **Auto-detection**: RetinaNet ResNet50 FPN V2 (COCO, 80 classes) with adjustable confidence threshold
 - **Manual annotation**: Click-and-drag to draw bounding boxes; click a box to select, then drag corners or edges to resize
 - **Auto-detect on load**: Optionally run detection automatically each time an image is opened
-- **Multiple export formats**: CSV and Pascal VOC XML
+- **Multiple export formats**: CSV, Pascal VOC XML, and YOLO
 - **Custom labels**: Add labels beyond the COCO set
 - **Dark / light theme**: Toggle in the header
 - **Keyboard shortcuts**: ← → to navigate images, Ctrl+S to save
@@ -105,6 +105,7 @@ Type a label name in **Add Custom Label** and press Enter or click **+**. Custom
 |--------|------|
 | CSV | `web/backend/annotations/annotations.csv` |
 | Pascal VOC XML | `web/backend/annotations/annotations_voc/<image>.xml` |
+| YOLO | `web/backend/annotations/annotations_yolo/<image>.txt` and `classes.txt` |
 
 CSV format: `image_name,x1,y1,x2,y2,label`
 

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -311,7 +311,7 @@ async def detect_objects(request: DetectionRequest):
 
 @app.post("/api/save")
 async def save_annotations(request: SaveAnnotationRequest):
-    """Save annotations to CSV and VOC XML format"""
+    """Save annotations to CSV, VOC XML, JSONL, and YOLO format"""
     try:
         from pascal_voc_writer import Writer
 
@@ -356,11 +356,57 @@ async def save_annotations(request: SaveAnnotationRequest):
         with open(jsonl_path, "a") as f:
             f.write(json.dumps(record) + "\n")
 
+        # Save to YOLO format
+        yolo_dir = ANNOTATIONS_DIR / "annotations_yolo"
+        yolo_dir.mkdir(exist_ok=True)
+
+        classes_path = yolo_dir / "classes.txt"
+
+        # Read existing classes to maintain stable IDs
+        classes = []
+        if classes_path.exists():
+            with open(classes_path, "r") as f:
+                classes = [line.strip() for line in f if line.strip()]
+
+        # Determine class IDs for current bboxes, adding new ones if necessary
+        for bbox in request.bboxes:
+            if bbox.label not in classes:
+                classes.append(bbox.label)
+
+        # Write updated classes.txt
+        with open(classes_path, "w") as f:
+            for cls_name in classes:
+                f.write(f"{cls_name}\n")
+
+        # Write YOLO annotation file
+        yolo_txt_path = yolo_dir / f"{base_name}.txt"
+        with open(yolo_txt_path, "w") as f:
+            for bbox in request.bboxes:
+                class_id = classes.index(bbox.label)
+
+                # YOLO format: normalized x_center y_center width height
+                img_w = request.image_width
+                img_h = request.image_height
+
+                x_center = ((bbox.x1 + bbox.x2) / 2) / img_w
+                y_center = ((bbox.y1 + bbox.y2) / 2) / img_h
+                width = (bbox.x2 - bbox.x1) / img_w
+                height = (bbox.y2 - bbox.y1) / img_h
+
+                # Ensure coordinates are within [0, 1]
+                x_center = max(0.0, min(1.0, x_center))
+                y_center = max(0.0, min(1.0, y_center))
+                width = max(0.0, min(1.0, width))
+                height = max(0.0, min(1.0, height))
+
+                f.write(f"{class_id} {x_center:.6f} {y_center:.6f} {width:.6f} {height:.6f}\n")
+
         return {
             "success": True,
             "csv_path": str(csv_path),
             "xml_path": str(xml_path),
             "jsonl_path": str(jsonl_path),
+            "yolo_path": str(yolo_txt_path),
         }
 
     except Exception as e:


### PR DESCRIPTION
This PR adds support for exporting annotations in YOLO format (.txt), in addition to the existing CSV, Pascal VOC XML, and JSONL formats.

YOLO format is a widely requested standard for modern object detection models (such as [YOLOv5/YOLOv8/YOLO11](https://docs.ultralytics.com/datasets/detect/)). Adding this export format allows users to train these models out-of-the-box using the annotations generated by Anno-Mage without needing a secondary conversion script.

### Changes Made

- Updated /api/save in web/backend/main.py to write bounding boxes to .txt files containing YOLO-formatted rows (class_id x_center y_center width height normalized between 0.0 and 1.0).
- The backend automatically maintains a classes.txt file alongside the .txt outputs to provide a stable mapping from class names to integer IDs used in the YOLO files.
- Updated README.md and web/README.md to document the new YOLO export location and features.

### Motivation
YOLO format is the standard for one of the most popular families of object detection models. Being able to directly export annotations to YOLO format saves an extra conversion step, simplifying the model training pipeline for many users.

### Testing

- Backend tests in web/backend/tests run successfully.
- Code style has been verified.